### PR TITLE
Last position cmd passed into Activate method of tracker

### DIFF
--- a/trackers/std_trackers/src/line_tracker_distance.cpp
+++ b/trackers/std_trackers/src/line_tracker_distance.cpp
@@ -11,7 +11,7 @@ class LineTrackerDistance : public trackers_manager::Tracker
   LineTrackerDistance(void);
 
   void Initialize(const ros::NodeHandle &nh);
-  bool Activate(void);
+  bool Activate(const quadrotor_msgs::PositionCommand::ConstPtr &cmd);
   void Deactivate(void);
 
   const quadrotor_msgs::PositionCommand::ConstPtr update(const nav_msgs::Odometry::ConstPtr &msg);
@@ -61,7 +61,7 @@ void LineTrackerDistance::Initialize(const ros::NodeHandle &nh)
                                 ros::TransportHints().tcpNoDelay());
 }
 
-bool LineTrackerDistance::Activate(void)
+bool LineTrackerDistance::Activate(const quadrotor_msgs::PositionCommand::ConstPtr &cmd)
 {
   // Only allow activation if a goal has been set
   if(goal_set_ && pos_set_)

--- a/trackers/std_trackers/src/line_tracker_min_jerk.cpp
+++ b/trackers/std_trackers/src/line_tracker_min_jerk.cpp
@@ -81,7 +81,7 @@ class LineTrackerMinJerk : public trackers_manager::Tracker
   LineTrackerMinJerk(void);
 
   void Initialize(const ros::NodeHandle &nh);
-  bool Activate(void);
+  bool Activate(const quadrotor_msgs::PositionCommand::ConstPtr &cmd);
   void Deactivate(void);
 
   const quadrotor_msgs::PositionCommand::ConstPtr update(
@@ -144,7 +144,7 @@ void LineTrackerMinJerk::Initialize(const ros::NodeHandle &nh)
                                 this, ros::TransportHints().tcpNoDelay());
 }
 
-bool LineTrackerMinJerk::Activate(void)
+bool LineTrackerMinJerk::Activate(const quadrotor_msgs::PositionCommand::ConstPtr &cmd)
 {
   // Only allow activation if a goal has been set
   if(goal_set_ && pos_set_)

--- a/trackers/std_trackers/src/line_tracker_trapezoid.cpp
+++ b/trackers/std_trackers/src/line_tracker_trapezoid.cpp
@@ -11,7 +11,7 @@ class LineTrackerTrapezoid : public trackers_manager::Tracker
   LineTrackerTrapezoid(void);
 
   void Initialize(const ros::NodeHandle &nh);
-  bool Activate(void);
+  bool Activate(const quadrotor_msgs::PositionCommand::ConstPtr &cmd);
   void Deactivate(void);
 
   const quadrotor_msgs::PositionCommand::ConstPtr update(const nav_msgs::Odometry::ConstPtr &msg);
@@ -65,7 +65,7 @@ void LineTrackerTrapezoid::Initialize(const ros::NodeHandle &nh)
                                 ros::TransportHints().tcpNoDelay());
 }
 
-bool LineTrackerTrapezoid::Activate(void)
+bool LineTrackerTrapezoid::Activate(const quadrotor_msgs::PositionCommand::ConstPtr &cmd)
 {
   // Only allow activation if a goal has been set
   if(goal_set_ && pos_set_)

--- a/trackers/std_trackers/src/line_tracker_yaw.cpp
+++ b/trackers/std_trackers/src/line_tracker_yaw.cpp
@@ -11,7 +11,7 @@ class LineTrackerYaw : public trackers_manager::Tracker
   LineTrackerYaw(void);
 
   void Initialize(const ros::NodeHandle &nh);
-  bool Activate(void);
+  bool Activate(const quadrotor_msgs::PositionCommand::ConstPtr &cmd);
   void Deactivate(void);
 
   const quadrotor_msgs::PositionCommand::ConstPtr update(const nav_msgs::Odometry::ConstPtr &msg);
@@ -72,7 +72,7 @@ void LineTrackerYaw::Initialize(const ros::NodeHandle &nh)
                                 ros::TransportHints().tcpNoDelay());
 }
 
-bool LineTrackerYaw::Activate(void)
+bool LineTrackerYaw::Activate(const quadrotor_msgs::PositionCommand::ConstPtr &cmd)
 {
   // Only allow activation if a goal has been set
   if(goal_set_ && pos_set_)

--- a/trackers/std_trackers/src/null_tracker.cpp
+++ b/trackers/std_trackers/src/null_tracker.cpp
@@ -6,7 +6,7 @@ class NullTracker : public trackers_manager::Tracker
 {
  public:
   void Initialize(const ros::NodeHandle &nh);
-  bool Activate(void);
+  bool Activate(const quadrotor_msgs::PositionCommand::ConstPtr &cmd);
   void Deactivate(void);
 
   const quadrotor_msgs::PositionCommand::ConstPtr update(const nav_msgs::Odometry::ConstPtr &msg);
@@ -17,7 +17,7 @@ void NullTracker::Initialize(const ros::NodeHandle &nh)
 {
 }
 
-bool NullTracker::Activate(void)
+bool NullTracker::Activate(const quadrotor_msgs::PositionCommand::ConstPtr &cmd)
 {
   return true;
 }

--- a/trackers/std_trackers/src/velocity_tracker.cpp
+++ b/trackers/std_trackers/src/velocity_tracker.cpp
@@ -10,7 +10,7 @@ class VelocityTracker : public trackers_manager::Tracker
   VelocityTracker(void);
 
   void Initialize(const ros::NodeHandle &nh);
-  bool Activate(void);
+  bool Activate(const quadrotor_msgs::PositionCommand::ConstPtr &cmd);
   void Deactivate(void);
 
   const quadrotor_msgs::PositionCommand::ConstPtr update(const nav_msgs::Odometry::ConstPtr &msg);
@@ -48,7 +48,7 @@ void VelocityTracker::Initialize(const ros::NodeHandle &nh)
   position_cmd_.kv[0] = kv_[0], position_cmd_.kv[1] = kv_[1], position_cmd_.kv[2] = kv_[2];
 }
 
-bool VelocityTracker::Activate(void)
+bool VelocityTracker::Activate(const quadrotor_msgs::PositionCommand::ConstPtr &cmd)
 {
   if(odom_set_)
   {

--- a/trackers/trackers_manager/include/trackers_manager/Tracker.h
+++ b/trackers/trackers_manager/include/trackers_manager/Tracker.h
@@ -14,7 +14,7 @@ class Tracker
   virtual ~Tracker(void) {}
 
   virtual void Initialize(const ros::NodeHandle &nh) = 0;
-  virtual bool Activate(void) = 0;
+  virtual bool Activate(const quadrotor_msgs::PositionCommand::ConstPtr &cmd) = 0;
   virtual void Deactivate(void) = 0;
 
   virtual const quadrotor_msgs::PositionCommand::ConstPtr update(const nav_msgs::Odometry::ConstPtr &msg) = 0;


### PR DESCRIPTION
This allows trackers to transition off of the last command sent to the robot.  In the case that no command has been sent to the robot, cmd will be null. 

This can prevent control errors from being integrated with every transition.
