### PR TITLE
mesh_visualization: Allow input from various common topic types

### DIFF
--- a/mav_manager/launch/demo.launch
+++ b/mav_manager/launch/demo.launch
@@ -75,7 +75,7 @@
       <param name="color/g" value="0.0"/>
       <param name="color/b" value="1.0"/>
       <param name="color/a" value="0.7"/>
-      <remap from="~odom" to="odom"/>
+      <remap from="~input" to="odom"/>
     </node>
 
     <!-- For serial communication -->

--- a/mesh_visualization/CMakeLists.txt
+++ b/mesh_visualization/CMakeLists.txt
@@ -6,12 +6,15 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE RelWithDebInfo)
 endif()
 
-find_package(catkin REQUIRED COMPONENTS roscpp nav_msgs visualization_msgs)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall")
+
+find_package(catkin REQUIRED COMPONENTS geometry_msgs nav_msgs roscpp
+  topic_tools visualization_msgs)
 
 catkin_package(
   INCLUDE_DIRS
   LIBRARIES
-  CATKIN_DEPENDS roscpp nav_msgs visualization_msgs
+  CATKIN_DEPENDS geometry_msgs nav_msgs roscpp topic_tools visualization_msgs
   DEPENDS)
 
 add_executable(mesh_visualization src/mesh_visualization.cpp)

--- a/mesh_visualization/launch/test.launch
+++ b/mesh_visualization/launch/test.launch
@@ -8,6 +8,6 @@
     <param name="color/g" value="0.0"/>
     <param name="color/b" value="1.0"/>
     <param name="color/a" value="0.7"/>
-    <remap from="~odom" to="/robot1/odom"/>
+    <remap from="~input" to="/robot1/odom"/>
   </node>
 </launch>

--- a/mesh_visualization/package.xml
+++ b/mesh_visualization/package.xml
@@ -1,33 +1,21 @@
-<package>
+<package format="2">
   <name>mesh_visualization</name>
   <version>1.0.0</version>
   <description>mesh_visualization</description>
+
   <maintainer email="kartikmohta@gmail.com">Kartik Mohta</maintainer>
   <maintainer email="michael.f.watterson@gmail.com">Michael Watterson</maintainer>
 
   <license>BSD</license>
 
-  <url type="website">http://ros.org/wiki/mesh_visualization</url>
-  <!-- <url type="bugtracker"></url> -->
-
   <author>Kartik Mohta</author>
 
-  <!-- Dependencies which this package needs to build itself. -->
   <buildtool_depend>catkin</buildtool_depend>
 
-  <!-- Dependencies needed to compile this package. -->
-  <build_depend>roscpp</build_depend>
-  <build_depend>nav_msgs</build_depend>
-  <build_depend>visualization_msgs</build_depend>
-
-  <!-- Dependencies needed after this package is compiled. -->
-  <run_depend>roscpp</run_depend>
-  <run_depend>nav_msgs</run_depend>
-  <run_depend>visualization_msgs</run_depend>
-
-  <!-- Dependencies needed only for running tests. -->
-  <!-- <test_depend>roscpp</test_depend> -->
-  <!-- <test_depend>nav_msgs</test_depend> -->
-  <!-- <test_depend>visualization_msgs</test_depend> -->
+  <depend>roscpp</depend>
+  <depend>geometry_msgs</depend>
+  <depend>nav_msgs</depend>
+  <depend>topic_tools</depend>
+  <depend>visualization_msgs</depend>
 
 </package>

--- a/mesh_visualization/src/mesh_visualization.cpp
+++ b/mesh_visualization/src/mesh_visualization.cpp
@@ -1,5 +1,8 @@
 #include <ros/ros.h>
+#include <geometry_msgs/PoseStamped.h>
+#include <geometry_msgs/PoseWithCovarianceStamped.h>
 #include <nav_msgs/Odometry.h>
+#include <topic_tools/shape_shifter.h>
 #include <visualization_msgs/Marker.h>
 
 static std::string mesh_resource;
@@ -7,22 +10,18 @@ static ros::Publisher pub_vis;
 static double color_r, color_g, color_b, color_a;
 static double scale_x, scale_y, scale_z;
 
-void odom_callback(const nav_msgs::Odometry::ConstPtr &msg)
+static void publishMarker(const std::string &frame_id,
+                          const geometry_msgs::Pose &pose)
 {
   visualization_msgs::Marker marker;
-  marker.header.frame_id = msg->header.frame_id;
-  marker.header.stamp = ros::Time(); // time 0 so that the marker will be displayed regardless of the current time
-  marker.ns = "mesh_visualization";
+  marker.header.frame_id = frame_id;
+  marker.header.stamp = ros::Time(); // time 0 so that the marker will be
+                                     // displayed regardless of the current time
+  marker.ns = ros::this_node::getName();
   marker.id = 0;
   marker.type = visualization_msgs::Marker::MESH_RESOURCE;
   marker.action = visualization_msgs::Marker::ADD;
-  marker.pose.position.x = msg->pose.pose.position.x;
-  marker.pose.position.y = msg->pose.pose.position.y;
-  marker.pose.position.z = msg->pose.pose.position.z;
-  marker.pose.orientation.x = msg->pose.pose.orientation.x;
-  marker.pose.orientation.y = msg->pose.pose.orientation.y;
-  marker.pose.orientation.z = msg->pose.pose.orientation.z;
-  marker.pose.orientation.w = msg->pose.pose.orientation.w;
+  marker.pose = pose;
   marker.scale.x = scale_x;
   marker.scale.y = scale_y;
   marker.scale.z = scale_z;
@@ -34,13 +33,40 @@ void odom_callback(const nav_msgs::Odometry::ConstPtr &msg)
   pub_vis.publish(marker);
 }
 
+static void any_callback(const topic_tools::ShapeShifter::ConstPtr &msg)
+{
+  // ROS_INFO_STREAM("Type: " << msg->getDataType());
+
+  if(msg->getDataType() == "geometry_msgs/PoseStamped")
+  {
+    auto pose_msg{msg->instantiate<geometry_msgs::PoseStamped>()};
+    publishMarker(pose_msg->header.frame_id, pose_msg->pose);
+  }
+  else if(msg->getDataType() == "geometry_msgs/PoseWithCovarianceStamped")
+  {
+    auto pose_msg{msg->instantiate<geometry_msgs::PoseWithCovarianceStamped>()};
+    publishMarker(pose_msg->header.frame_id, pose_msg->pose.pose);
+  }
+  else if(msg->getDataType() == "nav_msgs/Odometry")
+  {
+    auto odom_msg{msg->instantiate<nav_msgs::Odometry>()};
+    publishMarker(odom_msg->header.frame_id, odom_msg->pose.pose);
+  }
+  else
+  {
+    ROS_ERROR_STREAM(ros::this_node::getName()
+                     << " got unsupported message type " << msg->getDataType());
+  }
+}
+
 int main(int argc, char **argv)
 {
   ros::init(argc, argv, "mesh_visualization");
 
   ros::NodeHandle nh("~");
 
-  nh.param("mesh_resource", mesh_resource, std::string("package://mesh_visualization/mesh/hummingbird.mesh"));
+  nh.param("mesh_resource", mesh_resource,
+           std::string("package://mesh_visualization/mesh/hummingbird.mesh"));
   nh.param("color/r", color_r, 1.0);
   nh.param("color/g", color_g, 0.0);
   nh.param("color/b", color_b, 0.0);
@@ -49,7 +75,8 @@ int main(int argc, char **argv)
   nh.param("scale/y", scale_y, 1.0);
   nh.param("scale/z", scale_z, 1.0);
 
-  ros::Subscriber odom_sub = nh.subscribe("odom", 10, &odom_callback, ros::TransportHints().tcpNoDelay());
+  ros::Subscriber any_sub = nh.subscribe("input", 10, &any_callback,
+                                         ros::TransportHints().tcpNoDelay());
   pub_vis = nh.advertise<visualization_msgs::Marker>("robot", 10);
 
   ros::spin();

--- a/quadrotor_simulator/launch/sim.launch
+++ b/quadrotor_simulator/launch/sim.launch
@@ -51,7 +51,7 @@
       <param name="color/g" value="0.0"/>
       <param name="color/b" value="1.0"/>
       <param name="color/a" value="0.7"/>
-      <remap from="~odom" to="odom"/>
+      <remap from="~input" to="odom"/>
     </node>
 
   </group>


### PR DESCRIPTION
This allows input to be `geometry_msgs/PoseStamped`, `geometry_msgs/PoseWithCovarianceStamped` or `nav_msgs/Odometry`. Adding any additional type should be simple enough, just look at the code.

**Note:** This changes the input topic name for the mesh_visualization node from "odom" to "input" just to keep the name generic.
