### PR TITLE
Initialize cmd_valid_ to be false in initial_conditions

### DIFF
--- a/trackers/std_trackers/include/initial_conditions.h
+++ b/trackers/std_trackers/include/initial_conditions.h
@@ -9,6 +9,8 @@
 class InitialConditions
 {
  public:
+  InitialConditions();
+   
   void set_from_cmd(const quadrotor_msgs::PositionCommand::ConstPtr &msg);
   void set_from_odom(const nav_msgs::Odometry::ConstPtr &msg);
   Eigen::Vector3f pos() const { return pos_; }
@@ -17,14 +19,12 @@ class InitialConditions
   Eigen::Vector3f jrk() const { return jrk_; }
   float yaw() const { return yaw_; }
   float yaw_dot() const { return yaw_dot_; }
-  ros::Time time() const { return time_; }
   void reset();
 
  private:
   Eigen::Vector3f pos_, vel_, acc_, jrk_;
   float yaw_, yaw_dot_;
   bool cmd_valid_;
-  ros::Time time_;
 };
 
 #endif // STD_TRACKERS_INITIAL_CONDITIONS_H

--- a/trackers/std_trackers/src/initial_conditions.cpp
+++ b/trackers/std_trackers/src/initial_conditions.cpp
@@ -15,6 +15,17 @@
 #include <tf/transform_datatypes.h>
 #include <initial_conditions.h>
 
+InitialConditions::InitialConditions() :
+  pos_(Eigen::Vector3f::Zero()),
+  vel_(Eigen::Vector3f::Zero()),
+  acc_(Eigen::Vector3f::Zero()),
+  jrk_(Eigen::Vector3f::Zero()),
+  yaw_(0.0f),
+  yaw_dot_(0.0f),
+  cmd_valid_(false)
+{
+}
+
 void InitialConditions::set_from_cmd(
     const quadrotor_msgs::PositionCommand::ConstPtr &msg)
 {
@@ -32,8 +43,6 @@ void InitialConditions::set_from_cmd(
   yaw_ = msg->yaw;
   yaw_dot_ = msg->yaw_dot;
 
-  time_ = msg->header.stamp;
-
   cmd_valid_ = true;
 }
 
@@ -50,7 +59,6 @@ void InitialConditions::set_from_odom(const nav_msgs::Odometry::ConstPtr &msg)
     yaw_ = tf::getYaw(msg->pose.pose.orientation);
     yaw_dot_ = msg->twist.twist.angular.z; // TODO: Should double check which
                                            // frame (body or world) this is in
-    time_ = ros::Time::now();
   }
 }
 

--- a/trackers/std_trackers/src/line_tracker_distance.cpp
+++ b/trackers/std_trackers/src/line_tracker_distance.cpp
@@ -74,7 +74,6 @@ bool LineTrackerDistance::Activate(const quadrotor_msgs::PositionCommand::ConstP
     start_yaw_ = yaw_;
     active_ = true;
   }
-  ICs_.reset();
   return active_;
 }
 

--- a/trackers/std_trackers/src/line_tracker_min_jerk.cpp
+++ b/trackers/std_trackers/src/line_tracker_min_jerk.cpp
@@ -83,7 +83,6 @@ bool LineTrackerMinJerk::Activate(const quadrotor_msgs::PositionCommand::ConstPt
   {
     active_ = true;
   }
-  ICs_.reset();
   return active_;
 }
 
@@ -113,7 +112,7 @@ const quadrotor_msgs::PositionCommand::ConstPtr LineTrackerMinJerk::update(
 
   if(goal_set_)
   {
-    traj_start_ = ICs_.time();
+    traj_start_ = ros::Time::now();
     traj_duration_ = 0.5f;
 
     // Min-Jerk trajectory

--- a/trackers/std_trackers/src/line_tracker_trapezoid.cpp
+++ b/trackers/std_trackers/src/line_tracker_trapezoid.cpp
@@ -76,7 +76,6 @@ bool LineTrackerTrapezoid::Activate(const quadrotor_msgs::PositionCommand::Const
     start_yaw_ = cur_yaw_;
     active_ = true;
   }
-  ICs_.reset();
   return active_;
 }
 

--- a/trackers/std_trackers/src/line_tracker_yaw.cpp
+++ b/trackers/std_trackers/src/line_tracker_yaw.cpp
@@ -88,7 +88,6 @@ bool LineTrackerYaw::Activate(const quadrotor_msgs::PositionCommand::ConstPtr &c
 
     traj_start_ = ros::Time::now();
   }
-  ICs_.reset();
   return active_;
 }
 


### PR DESCRIPTION
This way, we do not need to reset in the tracker's activate method.
