### PR TITLE
bug fix in mavros_interface

### DIFF
--- a/mavros_interface/src/so3cmd_to_mavros_nodelet.cpp
+++ b/mavros_interface/src/so3cmd_to_mavros_nodelet.cpp
@@ -109,7 +109,7 @@ void SO3CmdToMavros::so3_cmd_callback(
       q_des;
 
   // check psi for stability
-  const Eigen::Matrix3d R_des(q_des_transformed);
+  const Eigen::Matrix3d R_des(q_des);
   const Eigen::Matrix3d R_cur(odom_q_);
 
   const float Psi =


### PR DESCRIPTION
was testing this code on an NSF robot when I found this issue. Psi is being calculated using the transformed desired attitude and the untransformed odometry. This was somehow changed when ported from the FLA repository.
