### PR TITLE
Initialize publishers before subscribers

### DIFF
--- a/mesh_visualization/src/mesh_visualization.cpp
+++ b/mesh_visualization/src/mesh_visualization.cpp
@@ -77,10 +77,10 @@ int main(int argc, char **argv)
 
   nh.param("new_frame_id", new_frame_id, std::string(""));
 
-  ros::Subscriber any_sub = nh.subscribe("input", 10, &any_callback,
-                                         ros::TransportHints().tcpNoDelay());
   pub_vis = nh.advertise<visualization_msgs::Marker>("robot", 10);
 
+  ros::Subscriber any_sub = nh.subscribe("input", 10, &any_callback,
+                                         ros::TransportHints().tcpNoDelay());
   ros::spin();
 
   return 0;

--- a/pid_control/src/pid_control_nodelet.cpp
+++ b/pid_control/src/pid_control_nodelet.cpp
@@ -163,6 +163,8 @@ void PIDControlNodelet::onInit(void)
   ki_[0] = ki_x, ki_[1] = ki_y, ki_[2] = ki_z;
   ki_yaw_ = ki_yaw;
 
+  trpy_command_pub_ = n.advertise<quadrotor_msgs::TRPYCommand>("trpy_cmd", 10);
+
   odom_sub_ = n.subscribe("odom", 10, &PIDControlNodelet::odom_callback, this,
                           ros::TransportHints().tcpNoDelay());
   position_cmd_sub_ = n.subscribe("position_cmd", 10, &PIDControlNodelet::position_cmd_callback, this,
@@ -170,8 +172,6 @@ void PIDControlNodelet::onInit(void)
 
   enable_motors_sub_ = n.subscribe("motors", 2, &PIDControlNodelet::enable_motors_callback, this,
                                    ros::TransportHints().tcpNoDelay());
-
-  trpy_command_pub_ = n.advertise<quadrotor_msgs::TRPYCommand>("trpy_cmd", 10);
 }
 
 #include <pluginlib/class_list_macros.h>

--- a/quad_decode_msg/src/quad_decode_msg_nodelet.cpp
+++ b/quad_decode_msg/src/quad_decode_msg_nodelet.cpp
@@ -51,12 +51,12 @@ void QuadDecodeMsg::onInit(void)
 {
   ros::NodeHandle priv_nh(getPrivateNodeHandle());
 
-  serial_sub_ = priv_nh.subscribe("serial", 10, &QuadDecodeMsg::serial_callback, this,
-                                  ros::TransportHints().tcpNoDelay());
-
   output_data_pub_ = priv_nh.advertise<quadrotor_msgs::OutputData>("output_data", 10);
   imu_output_pub_ = priv_nh.advertise<sensor_msgs::Imu>("imu", 10);
   status_pub_ = priv_nh.advertise<quadrotor_msgs::StatusData>("status", 10);
+
+  serial_sub_ = priv_nh.subscribe("serial", 10, &QuadDecodeMsg::serial_callback, this,
+                                  ros::TransportHints().tcpNoDelay());
 }
 
 #include <pluginlib/class_list_macros.h>

--- a/quad_encode_msg/src/quad_encode_msg_nodelet.cpp
+++ b/quad_encode_msg/src/quad_encode_msg_nodelet.cpp
@@ -67,14 +67,14 @@ void QuadEncodeMsg::onInit(void)
 
   priv_nh.param("channel", channel_, 0);
 
+  serial_msg_pub_ = priv_nh.advertise<quadrotor_msgs::Serial>("serial_msg", 10);
+
   so3_cmd_sub_ = priv_nh.subscribe("so3_cmd", 10, &QuadEncodeMsg::so3_cmd_callback, this,
                                                   ros::TransportHints().tcpNoDelay());
   trpy_cmd_sub_ = priv_nh.subscribe("trpy_cmd", 10, &QuadEncodeMsg::trpy_cmd_callback, this,
                                     ros::TransportHints().tcpNoDelay());
   pwm_cmd_sub_ = priv_nh.subscribe("pwm_cmd", 10, &QuadEncodeMsg::pwm_cmd_callback, this,
                                                   ros::TransportHints().tcpNoDelay());
-
-  serial_msg_pub_ = priv_nh.advertise<quadrotor_msgs::Serial>("serial_msg", 10);
 }
 
 #include <pluginlib/class_list_macros.h>

--- a/quad_serial_comm/src/quad_serial_comm_nodelet.cpp
+++ b/quad_serial_comm/src/quad_serial_comm_nodelet.cpp
@@ -53,10 +53,10 @@ void QuadSerialComm::onInit(void)
 
   sd_.Open(device, baud_rate);
 
+  output_data_pub_ = n.advertise<quadrotor_msgs::Serial>("from_robot", 10);
+
   serial_sub_ = n.subscribe("to_robot", 10, &QuadSerialComm::serial_callback, this,
                             ros::TransportHints().tcpNoDelay());
-
-  output_data_pub_ = n.advertise<quadrotor_msgs::Serial>("from_robot", 10);
 
   sd_.SetReadCallback(boost::bind(&QuadSerialComm::serial_read_callback, this, _1, _2));
   sd_.Start();

--- a/so3_control/src/so3_control_nodelet.cpp
+++ b/so3_control/src/so3_control_nodelet.cpp
@@ -195,6 +195,8 @@ void SO3ControlNodelet::onInit(void)
   corrections_[0] = corrections[0], corrections_[1] = corrections[1], corrections_[2] = corrections[2];
 
 
+  so3_command_pub_ = n.advertise<quadrotor_msgs::SO3Command>("so3_cmd", 10);
+
   odom_sub_ = n.subscribe("odom", 10, &SO3ControlNodelet::odom_callback, this, ros::TransportHints().tcpNoDelay());
   position_cmd_sub_ = n.subscribe("position_cmd", 10, &SO3ControlNodelet::position_cmd_callback, this,
                                   ros::TransportHints().tcpNoDelay());
@@ -202,8 +204,6 @@ void SO3ControlNodelet::onInit(void)
                                    ros::TransportHints().tcpNoDelay());
   corrections_sub_ = n.subscribe("corrections", 10, &SO3ControlNodelet::corrections_callback, this,
                                  ros::TransportHints().tcpNoDelay());
-
-  so3_command_pub_ = n.advertise<quadrotor_msgs::SO3Command>("so3_cmd", 10);
 }
 
 #include <pluginlib/class_list_macros.h>

--- a/trackers/trackers_manager/src/trackers_manager.cpp
+++ b/trackers/trackers_manager/src/trackers_manager.cpp
@@ -79,11 +79,11 @@ void TrackersManager::onInit(void)
     }
   }
 
-  sub_odom_ = priv_nh.subscribe("odom", 10, &TrackersManager::odom_callback, this,
-                                ros::TransportHints().tcpNoDelay());
-
   pub_cmd_ = priv_nh.advertise<quadrotor_msgs::PositionCommand>("cmd", 10);
   pub_status_ = priv_nh.advertise<quadrotor_msgs::TrackerStatus>("status", 10);
+
+  sub_odom_ = priv_nh.subscribe("odom", 10, &TrackersManager::odom_callback, this,
+                                ros::TransportHints().tcpNoDelay());
 
   srv_tracker_ = priv_nh.advertiseService("transition", &TrackersManager::transition_callback, this);
 }


### PR DESCRIPTION
To avoid runtime errors of the form:
```
ASSERTION FAILED
  file = /opt/ros/kinetic/include/ros/publisher.h
  line = 69
  cond = false
  message = Call to publish() on an invalid Publisher
```

Have seen some of these crop up when testing the FLA stuff in simulation.