### PR TITLE
mavros_interface: Add a num_props param, change kf to per prop value

### DIFF
--- a/mavros_interface/launch/test.launch
+++ b/mavros_interface/launch/test.launch
@@ -2,10 +2,11 @@
   <arg name="robot" default="/"/>
   <arg name="odom" default="odom"/>
   <arg name="so3_cmd" default="so3_cmd"/>
-  <arg name="kf" default="8.54858e-06"/>
+  <arg name="num_props" default="4"/>
+  <arg name="kf" default="2.137145e-6"/>
   <arg name="lin_cof_a" default="0.0015"/>
   <arg name="lin_int_b" default="-1.5334"/>
- 
+
   <group ns="$(arg robot)">
     <node pkg="nodelet"
       type="nodelet"
@@ -14,8 +15,8 @@
       required="true"
       clear_params="true"
       output="screen">
-      <param name="cof_a" value="$(arg cof_a)"/>
-      <param name="power_b" value="$(arg power_b)"/>
+      <param name="num_props" value="$(arg num_props)"/>
+      <param name="kf" value="$(arg kf)"/>
       <param name="lin_cof_a" value="$(arg lin_cof_a)"/>
       <param name="lin_int_b" value="$(arg lin_int_b)"/>
       <remap from="~odom" to="$(arg odom)"/>

--- a/mavros_interface/package.xml
+++ b/mavros_interface/package.xml
@@ -4,7 +4,8 @@
   <description>mavros_interface</description>
   <maintainer email="anurag.makineni@gmail.com">Anurag Makineni</maintainer>
   <maintainer email="JustinThomas@jtwebs.net">Justin Thomas</maintainer>
-  
+  <maintainer email="kartikmohta@gmail.com">Kartik Mohta</maintainer>
+
   <license>BSD</license>
 
   <!-- Dependencies which this package needs to build itself. -->

--- a/mavros_interface/src/so3cmd_to_mavros_nodelet.cpp
+++ b/mavros_interface/src/so3cmd_to_mavros_nodelet.cpp
@@ -22,9 +22,10 @@ class SO3CmdToMavros : public nodelet::Nodelet
   bool odom_set_, imu_set_, so3_cmd_set_;
   Eigen::Quaterniond odom_q_, imu_q_;
   double kf_, lin_cof_a_, lin_int_b_;
+  int num_props_;
 
   ros::Publisher attitude_raw_pub_;
-  ros::Publisher odom_pose_pub_; // For sending PoseStamped to firmware.
+  ros::Publisher odom_pose_pub_; // For sending PoseStamped to firmware
 
   ros::Subscriber so3_cmd_sub_;
   ros::Subscriber odom_sub_;
@@ -103,7 +104,7 @@ void SO3CmdToMavros::so3_cmd_callback(
   const tf::Quaternion tf_imu_odom_yaw = imu_tf_yaw * odom_tf_yaw.inverse();
 
   // transform!
-  Eigen::Quaterniond q_des_transformed =
+  const Eigen::Quaterniond q_des_transformed =
       Eigen::Quaterniond(tf_imu_odom_yaw.w(), tf_imu_odom_yaw.x(),
                          tf_imu_odom_yaw.y(), tf_imu_odom_yaw.z()) *
       q_des;
@@ -130,11 +131,10 @@ void SO3CmdToMavros::so3_cmd_callback(
     ROS_WARN_THROTTLE(1,"psi > 1.0, throttle set to 0.0 in mavros_interface.");
   }
 
-  // Scale force to be proportional to rotor velocity (rad/s).
-  // Note: This ignores the number of propellers.
-  throttle = std::sqrt(throttle / kf_);
+  // Scale force to individual rotor velocities (rad/s).
+  throttle = std::sqrt(throttle / num_props_ / kf_);
 
-  // Scaling from proportional rotor velocity (rad/s) to att_throttle for pixhawk
+  // Scaling from rotor velocity (rad/s) to att_throttle for pixhawk
   throttle = lin_cof_a_ * throttle + lin_int_b_;
 
   // clamp from 0.0 to 1.0
@@ -169,19 +169,22 @@ void SO3CmdToMavros::onInit(void)
   ros::NodeHandle priv_nh(getPrivateNodeHandle());
 
   // get thrust scaling parameters
-  // Note that this is ignoring a constant based on the number of props, which
-  // is captured with the lin_cof_a variable later.
-  if(priv_nh.getParam("kf", kf_))
-    ROS_INFO("Using kf=%F so that prop speed = sqrt(f / kf) to scale force to speed.", kf_);
+  if(priv_nh.getParam("num_props", num_props_))
+    ROS_INFO("Got number of props: %d", num_props_);
   else
-    ROS_ERROR("Must set kf param for thrust scaling. Motor speed = sqrt(thrust / kf)");
+    ROS_ERROR("Must set num_props param");
 
-  ROS_ASSERT_MSG(kf_ > 0, "kf must be positive. kf = %d", kf_);
+  if(priv_nh.getParam("kf", kf_))
+    ROS_INFO("Using kf=%g so that prop speed = sqrt(f / num_props / kf) to scale force to speed.", kf_);
+  else
+    ROS_ERROR("Must set kf param for thrust scaling. Motor speed = sqrt(thrust / num_props / kf)");
+
+  ROS_ASSERT_MSG(kf_ > 0, "kf must be positive. kf = %g", kf_);
 
   // get thrust scaling parameters
   if(priv_nh.getParam("lin_cof_a", lin_cof_a_) &&
      priv_nh.getParam("lin_int_b", lin_int_b_))
-    ROS_INFO("Using %F*x + %F to scale prop speed to att_throttle.", lin_cof_a_,
+    ROS_INFO("Using %g*x + %g to scale prop speed to att_throttle.", lin_cof_a_,
              lin_int_b_);
   else
     ROS_ERROR("Must set coefficients for thrust scaling (scaling from rotor "


### PR DESCRIPTION
Allows the use of the same kf value for the same motor/prop combination
for quad or hex configs by just changing the num_props param