### PR TITLE
Add small comment regarding imu and odom transformation for mavros

### DIFF
--- a/interfaces/kr_mavros_interface/README.md
+++ b/interfaces/kr_mavros_interface/README.md
@@ -2,6 +2,10 @@
 
 This node translates `kr_mav_msgs/SO3Command` to `mavros_msgs/AttitudeTarget`.
 
+Please note that your flight controller yaw orientation estimation may be
+different to your odom system orientation estimation. We should transform our
+`kr_mav_msgs/SO3Command` into the flight controller yaw before publishing it.
+
 #### `mavros_msgs` requirement
 
 This node requires `mavros_msgs` to be present when building. If `mavros_msgs` is not found when building the first time, a warning is given and nothing in this package is built. If `mavros_msgs` is installed after this, force a recheck by adding `--force-cmake` to the `catkin_make`/`catkin build` command.

--- a/interfaces/kr_mavros_interface/src/so3cmd_to_mavros_nodelet.cpp
+++ b/interfaces/kr_mavros_interface/src/so3cmd_to_mavros_nodelet.cpp
@@ -79,6 +79,8 @@ void SO3CmdToMavros::so3_cmd_callback(const kr_mav_msgs::SO3Command::ConstPtr &m
     return;
   }
 
+  // transform to take into consideration the different yaw of the flight
+  // controller imu and the odom
   // grab desired forces and rotation from so3
   const Eigen::Vector3d f_des(msg->force.x, msg->force.y, msg->force.z);
 


### PR DESCRIPTION
We had some trouble understanding this part of the stack with @XuRobotics, and @ke-sun helped us figure it out. 

I guess that the confusion came from https://github.com/KumarRobotics/kr_mav_control/blob/master/doc/kr_mav_control_block_diag.png, because the arrow from the MAVROS interface to the PX4 is unidirectional. There is feedback from the PX4 to correct the different yaw angles between the flight controller and the odom frames. Do you think we also need to modify the figure @tdinesh?

Thanks!