### PR TITLE
Use python3 in env instead of python

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ The multi robot examples uses following packages.
 
 [Running multiple robots with Gazebo](doc/MultiGazebo.md)
 
+This code has been tested with ROS Noetic on Ubuntu 20.04.
+
 ### Block Diagram
 
 The following block diagram shows how the packages in the repo fit together.

--- a/interfaces/kr_python_interface/setup.py
+++ b/interfaces/kr_python_interface/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from distutils.core import setup
 from catkin_pkg.python_setup import generate_distutils_setup

--- a/interfaces/kr_python_interface/src/kr_python_interface/mav_interface.py
+++ b/interfaces/kr_python_interface/src/kr_python_interface/mav_interface.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 from __future__ import print_function
 
 import rospy

--- a/kr_mav_controllers/cfg/SO3.cfg
+++ b/kr_mav_controllers/cfg/SO3.cfg
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 PACKAGE = "kr_mav_controllers"
 
 from dynamic_reconfigure.parameter_generator_catkin import *

--- a/kr_mav_launch/scripts/demo_lissajous.py
+++ b/kr_mav_launch/scripts/demo_lissajous.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import rospy
 import smach

--- a/rqt_mav_manager/scripts/rqt_mav_manager
+++ b/rqt_mav_manager/scripts/rqt_mav_manager
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/trackers/kr_trackers/scripts/twist_to_velocity_goal.py
+++ b/trackers/kr_trackers/scripts/twist_to_velocity_goal.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 from __future__ import print_function
 
 import rospy

--- a/trackers/kr_trackers/scripts/waypoints_to_action.py
+++ b/trackers/kr_trackers/scripts/waypoints_to_action.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 from __future__ import print_function
 
 import rospy


### PR DESCRIPTION
Some scripts of `kr_mav_control` fail in 20.04/Noetic due to the wrong env. This should fix it, but it may break compatibility with Melodic. We are currently using noetic in most of our robots in the lab, can we do this jump?