### PR TITLE
Support for Brushless Crazyflie

### DIFF
--- a/interfaces/kr_crazyflie_interface/CMakeLists.txt
+++ b/interfaces/kr_crazyflie_interface/CMakeLists.txt
@@ -17,7 +17,8 @@ find_package(
              nav_msgs
              geometry_msgs
              kr_mav_msgs
-             nodelet)
+             nodelet
+             crazyflie_driver)
 find_package(Eigen3 REQUIRED)
 
 include_directories(${catkin_INCLUDE_DIRS} ${EIGEN3_INCLUDE_DIR})
@@ -31,6 +32,7 @@ catkin_package(
   geometry_msgs
   kr_mav_msgs
   nodelet
+  crazyflie_driver
   DEPENDS
   EIGEN3)
 

--- a/interfaces/kr_crazyflie_interface/package.xml
+++ b/interfaces/kr_crazyflie_interface/package.xml
@@ -16,6 +16,7 @@
   <depend>geometry_msgs</depend>
   <depend>kr_mav_msgs</depend>
   <depend>nodelet</depend>
+  <depend>crazyflie_driver</depend>
 
   <export>
     <nodelet plugin="${prefix}/nodelet_plugin.xml"/>

--- a/interfaces/kr_crazyflie_interface/src/so3cmd_to_crazyflie_nodelet.cpp
+++ b/interfaces/kr_crazyflie_interface/src/so3cmd_to_crazyflie_nodelet.cpp
@@ -65,23 +65,13 @@ void SO3CmdToCrazyflie::send_arming_request(bool arm)
 {
   ROS_INFO("Setting arm to: %d", arm);
   
-  // Create a packet to arm or disarm
-  // crazyflie_driver::crtpPacket packet;
-  // packet.header = 0x0D;
-  // packet.size = 1;  // Payload length is 1 byte for arm/disarm
-  // // Clear the data array before populating it
-  // std::fill(packet.data.begin(), packet.data.end(), 0);
-  // // Set the payload (1 byte for arm or disarm)
-  // packet.data[0] = arm ? 1 : 0;  // 1 for arm, 0 for disarm
-
   // Create a custom packet for arming/disarming
+  // https://www.bitcraze.io/documentation/repository/crazyflie-firmware/master/functional-areas/crtp/crtp_platform/
   crazyflie_driver::crtpPacket packet;
-  packet.header = 220;  // Same as 13 in decimal
-  packet.size = 2;  // Payload length of 2 bytes
-  // Set the first byte of the payload to 1 (indicating the arming/disarming operation)
-  packet.data[0] = 1;
-  // Set the second byte to arm/disarm (1 for arm, 0 for disarm)
-  packet.data[1] = arm ? 1 : 0;
+  packet.header = 220;  // Port 13 but byteshifted following https://github.com/bitcraze/crazyflie-lib-python/blob/master/cflib/crtp/crtpstack.py#L120-L132
+  packet.size = 2;      // Payload length
+  packet.data[0] = 1;   // Channel 0 -- Platform commands
+  packet.data[1] = arm ? 1 : 0;  // Arm message (bool).
 
   // Call the sendPacket service to send the packet
   crazyflie_driver::sendPacket srv;

--- a/interfaces/kr_crazyflie_interface/src/so3cmd_to_crazyflie_nodelet.cpp
+++ b/interfaces/kr_crazyflie_interface/src/so3cmd_to_crazyflie_nodelet.cpp
@@ -51,6 +51,8 @@ class SO3CmdToCrazyflie : public nodelet::Nodelet
   int thrust_pwm_min_;  // Necessary to overcome stiction
   int thrust_pwm_max_;  // Mapped to PWM
 
+  bool send_ctbr_cmds_;
+
   int motor_status_;
 };
 
@@ -165,8 +167,13 @@ void SO3CmdToCrazyflie::so3_cmd_callback(const kr_mav_msgs::SO3Command::ConstPtr
   // TODO change this check to be a param
   // throttle the publish rate
   // if ((ros::Time::now() - last_so3_cmd_time_).toSec() > 1.0/30.0){
-  crazy_vel_cmd->linear.y = roll_des + msg->aux.angle_corrections[0];
-  crazy_vel_cmd->linear.x = pitch_des + msg->aux.angle_corrections[1];
+  if (send_ctbr_cmds_) {
+    crazy_vel_cmd->linear.y = msg->angular_velocity.x;  // ctbr_cmd->angular_velocity.x = roll rate
+    crazy_vel_cmd->linear.x = msg->angular_velocity.y;  // ctbr_cmd->angular_velocity.y = pitch rate
+  } else {
+    crazy_vel_cmd->linear.y = roll_des + msg->aux.angle_corrections[0];
+    crazy_vel_cmd->linear.x = pitch_des + msg->aux.angle_corrections[1];
+  }
   crazy_vel_cmd->linear.z = CLAMP(thrust_pwm, thrust_pwm_min_, thrust_pwm_max_);
 
   // ROS_INFO("commanded thrust is %2.2f", CLAMP(thrust_pwm, thrust_pwm_min_, thrust_pwm_max_));
@@ -207,6 +214,9 @@ void SO3CmdToCrazyflie::onInit(void)
 
   // get param for so3 command timeout duration
   priv_nh.param("so3_cmd_timeout", so3_cmd_timeout_, 0.1);
+
+  // get param for sending ctbr cmds, default is to send TRPY commands as attitude
+  priv_nh.param("send_ctbr_cmds", send_ctbr_cmds_, false);
 
   priv_nh.param("thrust_pwm_max", thrust_pwm_max_, 60000);
   priv_nh.param("thrust_pwm_min", thrust_pwm_min_, 10000);

--- a/rqt_mav_manager/src/rqt_mav_manager/__init__.py
+++ b/rqt_mav_manager/src/rqt_mav_manager/__init__.py
@@ -6,6 +6,7 @@ import rospkg
 import rospy
 from python_qt_binding import loadUi
 from python_qt_binding.QtWidgets import QWidget
+from PyQt5.QtCore import QTimer
 from rqt_gui_py.plugin import Plugin
 
 import kr_mav_manager.srv
@@ -66,11 +67,15 @@ class MavManagerUi(Plugin):
 
   def _on_motors_off_pressed(self):
     try:
+      self._widget.motors_on_push_button.setEnabled(False)
       motors_topic = '/'+self.robot_name+'/'+self.mav_node_name+'/motors'
       rospy.wait_for_service(motors_topic, timeout=1.0)
       motors_off = rospy.ServiceProxy(motors_topic, std_srvs.srv.SetBool)
       resp = motors_off(False)
       print(resp.success)
+      
+      QTimer.singleShot(3000, lambda: self._widget.motors_on_push_button.setEnabled(True))
+   
     except rospy.ServiceException as e:
       print("Service call failed: %s"%e)
     except(rospy.ROSException) as e:


### PR DESCRIPTION
Added support for the brushless Crazyflie in `interfaces/kr_crazyflie_interface`. Unlike the brushed version, the brushless Crazyflie has to be armed before the motors can spin. To get around this, the Crazyflie interface now sends custom arming/disarming packets when Motors On and Motors Off are pressed. 

Currently, when the drone is disarmed its internal state machine enters a locked state where a reboot is required (unsure if this is by design). The workaround is to send a reboot packet when Motors Off is pressed. During the reboot process, Motors On does not work, so the button is disabled for 3 seconds. 

This code was tested on both the brushed and brushless Crazyflies. 